### PR TITLE
Create catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: bibt-libraries
+  title: "BIBT Libraries"
+  description: Blue Team Python Libraries
+  links:
+    - url: https://github.com/broadinstitute/bibt-libraries
+      title: "BIBT Libraries"
+      icon: dashboard
+  tags:
+    - bits
+    - bits-tools
+    - security
+  annotations:
+    github.com/project-slug: broadinstitute/bibt-libraries
+    backstage.io/techdocs-ref: dir:.
+spec:
+  type: system
+  owner: bits-blue-team
+  lifecycle: production


### PR DESCRIPTION
This will add this repo as a "System" in [Backstage](https://backstage.broadinstitute.org)  a System is a collections of components, such as API's adding this System - which will let us add the other repos as API components! 

More info on the system model can found here: https://backstage.io/docs/features/software-catalog/system-model/  

As well as some docs [here](https://backstage.broadinstitute.org/catalog/default/component/backstage/docs/techdocs/)!